### PR TITLE
Update Symfony requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "symfony/dependency-injection"  : "~2.3|~3.0",
         "symfony/http-foundation"       : "~2.3|~3.0",
         "symfony/http-kernel"           : "~2.3|~3.0",
-        "symfony/security"              : "~2.3|~3.0",
-        "symfony/security-bundle"       : "~2.3|~3.0"
+        "symfony/security"              : "~2.6|~3.0",
+        "symfony/security-bundle"       : "~2.6|~3.0"
     },
     "autoload": {
         "psr-4": { "EasyCorp\\Bundle\\EasySecurityBundle\\": "" },


### PR DESCRIPTION
`TokenStorageInterface` and `AuthorizationCheckerInterface` is only available since Symfony 2.6
