### PR TITLE
Some changes/bug fixes

### DIFF
--- a/DependencyInjection/EasySecurityExtension.php
+++ b/DependencyInjection/EasySecurityExtension.php
@@ -26,8 +26,10 @@ class EasySecurityExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        $this->addClassesToCompile(array(
-            'EasyCorp\\Bundle\\EasySecurityBundle\\Security\\Security',
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'EasyCorp\\Bundle\\EasySecurityBundle\\Security\\Security',
+            ));
+        }
     }
 }

--- a/Security/Security.php
+++ b/Security/Security.php
@@ -219,7 +219,6 @@ class Security
     public function login(UserInterface $user, $firewallName = 'main')
     {
         $token = new UsernamePasswordToken($user, $user->getPassword(), $firewallName, $user->getRoles());
-        $token->setAuthenticated(true);
         $this->tokenStorage->setToken($token);
 
         $this->session->set('_security_'.$firewallName, serialize($token));


### PR DESCRIPTION
1. `Extension::addClassesToCompile()` is deprecated in Symfony 3.3
2. Calling `UsernamePasswordToken::setAuthenticated()` throws a `\LogicException` [ref](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php#L52)