### PR TITLE
Bug fix

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,7 +10,6 @@
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="security.password_encoder" />
             <argument type="service" id="security.authentication_utils" />
-            <argument type="service" id="session" />
             <argument type="service" id="security.role_hierarchy" on-invalid="null" />
         </service>
     </services>


### PR DESCRIPTION
https://github.com/EasyCorp/easy-security-bundle/commit/e4cc0a3d498f9b6ac075fc5fcfabda584cedbdbd#diff-a250e7565daed7b88f994541e152e67cR37

Error:
```
Type error: Argument 5 passed to EasyCorp\Bundle\EasySecurityBundle\Security\Security::__construct() must be an instance of Symfony\Component\Security\Core\Role\RoleHierarchy, instance of Symfony\Component\HttpFoundation\Session\Session given, called in /var/www/winlytics/var/cache/dev/appDevDebugProjectContainer.php on line 2636
```