### PR TITLE
Remove deprecated addClassesToCompile call

### DIFF
--- a/DependencyInjection/EasySecurityExtension.php
+++ b/DependencyInjection/EasySecurityExtension.php
@@ -25,11 +25,5 @@ class EasySecurityExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
-
-        if (PHP_VERSION_ID < 70000) {
-            $this->addClassesToCompile(array(
-                'EasyCorp\\Bundle\\EasySecurityBundle\\Security\\Security',
-            ));
-        }
     }
 }


### PR DESCRIPTION
Hi there,

```
 Symfony\Component\HttpKernel\DependencyInjection\Extension::addClassesToCompile() is deprecated since version 3.3, to be removed in 4.0. 
```

Cheers,